### PR TITLE
Handle the KVO subclassing upon adding observers to a controller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 language: objective-c
+before_install:
+    - (ruby --version)
+    - sudo chown -R travis ~/Library/RubyMotion
+    - mkdir -p ~/Library/RubyMotion/build
+    - sudo motion update
+script:
+    - bundle install
+    - bundle exec rake clean
+    - bundle exec rake spec

--- a/lib/elevate/elevate.rb
+++ b/lib/elevate/elevate.rb
@@ -9,7 +9,7 @@ module Elevate
     end
 
     def task_definitions
-      @task_definitions ||= {}
+      @@task_definitions ||= {}
     end
   end
 
@@ -30,8 +30,7 @@ module Elevate
   def launch(name, args = {})
     raise ArgumentError, "args must be a Hash" unless args.is_a? Hash
 
-    controller_class = self.class.to_s.start_with?("NSKVONotifying_") ? self.class.superclass : self.class
-    definition = controller_class.task_definitions[name.to_sym]
+    definition = self.class.task_definitions[name.to_sym]
 
     task = Task.new(definition, self, active_tasks)
     task.start(args)

--- a/lib/elevate/elevate.rb
+++ b/lib/elevate/elevate.rb
@@ -30,7 +30,8 @@ module Elevate
   def launch(name, args = {})
     raise ArgumentError, "args must be a Hash" unless args.is_a? Hash
 
-    definition = self.class.task_definitions[name.to_sym]
+    controller_class = self.class.to_s.start_with?("NSKVONotifying_") ? self.class.superclass : self.class
+    definition = controller_class.task_definitions[name.to_sym]
 
     task = Task.new(definition, self, active_tasks)
     task.start(args)

--- a/spec/elevate_spec.rb
+++ b/spec/elevate_spec.rb
@@ -127,6 +127,9 @@ class TestController
   end
 end
 
+class SubclassController < TestController
+end
+
 describe Elevate do
   extend WebStub::SpecHelpers
 
@@ -306,6 +309,12 @@ describe Elevate do
         @controller.invocations[:timeout].should.not.be.nil
       end
 
+    end
+  end
+
+  describe ".task_definitions" do
+    it "includes task definitions from the superclass in subclasses" do
+      SubclassController.task_definitions.should.equal TestController.task_definitions
     end
   end
 end


### PR DESCRIPTION
When a key-value observer is added to a controller, the class becomes a NSKVONotifying class that doesn't have the task definitions. The task definitions can be found in the superclass.
