### PR TITLE
Allows self signed certs

### DIFF
--- a/lib/elevate/http/request.rb
+++ b/lib/elevate/http/request.rb
@@ -50,6 +50,8 @@ module HTTP
         url += "?" + URI.encode_query(options[:query])
       end
 
+      @allow_self_sign_certificate = options.fetch(:allow_self_sign_certificate, false)
+
       options[:headers] ||= {}
 
       if root = options.delete(:json)
@@ -171,6 +173,22 @@ module HTTP
       @response.url = request.URL.absoluteString
 
       request
+    end
+
+    def connection(connection, canAuthenticateAgainstProtectionSpace: protectionSpace)
+      @allow_self_sign_certificate
+    end
+
+    def connection(connection, didReceiveAuthenticationChallenge: challenge)
+      if @allow_self_sign_certificate
+        credential = NSURLCredential.credentialForTrust(challenge.protectionSpace.serverTrust)
+        challenge.sender.useCredential(
+          credential,
+          forAuthenticationChallenge:challenge
+        )
+
+        challenge.sender.continueWithoutCredentialForAuthenticationChallenge(challenge)
+      end
     end
 
     def get_authorization_header(credentials)


### PR DESCRIPTION
Subsequently found out that you can enable self signed certs by dragging the certificate file onto the emulator, which allows you to install it on that device. I still feel this PR is still valid for development purposes where you aren't able to do this.
- Adds an option to allow self signed certificates
- Overrides connection:canAuthenticateAgainstProtectionSpace and connection: didReceiveAuthenticationChallenge to use new option.
